### PR TITLE
Added JaCoCO unit test runtime agent and report generator to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>at.fhhagenberg.sqelevator</groupId>
-    <artifactId>mqtt-elevator</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <artifactId>mqtt-elevator-team-c</artifactId>
+    <version>0.0.3-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -79,6 +79,47 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.1</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <!-- Executes unit tests and integration tests under code coverage and creates two independent coverage reports-->
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.60</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/at/wielander/elevator/Model/ElevatorAlgorithmTest.java
+++ b/src/test/java/at/wielander/elevator/Model/ElevatorAlgorithmTest.java
@@ -1,0 +1,26 @@
+package at.wielander.elevator.Model;
+
+class ElevatorAlgorithmTest {
+/*
+    private ElevatorAlgorithm algorithm;
+
+    @BeforeEach
+    void setUp() {
+        algorithm = new ElevatorAlgorithm();
+    }
+
+    @Test
+    void testProcessCallRequest() {
+        // Testet, ob der Algorithmus eine Anforderung korrekt verarbeitet
+        int floor = 2;
+        algorithm.processCallRequest(floor);
+        assertEquals(floor, algorithm.getCurrentFloor());
+    }
+
+    @Test
+    void testHandleOverload() {
+        // Testet, ob die Überlastung korrekt behandelt wird
+        algorithm.setPayload(1500);
+        assertTrue(algorithm.isOverloaded());
+    }*/
+}


### PR DESCRIPTION
Amended the pom.xml to include the JaCoCo runner agent and the test report generator. At present, only reports for unit tests will be generated.